### PR TITLE
Fix equality for empty intervals

### DIFF
--- a/src/lib/Rampart.hs
+++ b/src/lib/Rampart.hs
@@ -299,6 +299,7 @@ relate x y =
     gxly = compare (greater x) (lesser y)
     gxgy = compare (greater x) (greater y)
   in case (lxly, lxgy, gxly, gxgy) of
+    (EQ, _, _, EQ) -> Equal
     (_, _, LT, _) -> Before
     (_, _, EQ, _) -> Meets
     (_, EQ, _, _) -> MetBy
@@ -307,7 +308,6 @@ relate x y =
     (LT, _, _, EQ) -> FinishedBy
     (LT, _, _, GT) -> Contains
     (EQ, _, _, LT) -> Starts
-    (EQ, _, _, EQ) -> Equal
     (EQ, _, _, GT) -> StartedBy
     (GT, _, _, LT) -> During
     (GT, _, _, EQ) -> Finishes

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -68,6 +68,55 @@ main = Hspec.hspec . Hspec.describe "Rampart" $ do
     Hspec.it "identifies the after relation" $ do
       relate (8, 9) (3, 7) `Hspec.shouldBe` Rampart.After
 
+    Hspec.describe "empty left interval" $ do
+
+      Hspec.it "before" $ do
+        relate (2, 2) (3, 7) `Hspec.shouldBe` Rampart.Before
+
+      Hspec.it "at lesser" $ do
+        relate (3, 3) (3, 7) `Hspec.shouldBe` Rampart.Meets
+        Hspec.pendingWith "https://github.com/tfausak/rampart/issues/2"
+
+      Hspec.it "during" $ do
+        relate (5, 5) (3, 7) `Hspec.shouldBe` Rampart.During
+
+      Hspec.it "at greater" $ do
+        relate (7, 7) (3, 7) `Hspec.shouldBe` Rampart.MetBy
+        Hspec.pendingWith "https://github.com/tfausak/rampart/issues/2"
+
+      Hspec.it "after" $ do
+        relate (8, 8) (3, 7) `Hspec.shouldBe` Rampart.After
+
+    Hspec.describe "empty right interval" $ do
+
+      Hspec.it "before" $ do
+        relate (3, 7) (2, 2) `Hspec.shouldBe` Rampart.After
+
+      Hspec.it "at lesser" $ do
+        relate (3, 7) (3, 3) `Hspec.shouldBe` Rampart.MetBy
+        Hspec.pendingWith "https://github.com/tfausak/rampart/issues/2"
+
+      Hspec.it "during" $ do
+        relate (3, 7) (5, 5) `Hspec.shouldBe` Rampart.Contains
+
+      Hspec.it "at greater" $ do
+        relate (3, 7) (7, 7) `Hspec.shouldBe` Rampart.Meets
+        Hspec.pendingWith "https://github.com/tfausak/rampart/issues/2"
+
+      Hspec.it "after" $ do
+        relate (3, 7) (8, 8) `Hspec.shouldBe` Rampart.Before
+
+    Hspec.describe "both empty intervals" $ do
+
+      Hspec.it "before" $ do
+        relate (4, 4) (5, 5) `Hspec.shouldBe` Rampart.Before
+
+      Hspec.it "equal" $ do
+        relate (5, 5) (5, 5) `Hspec.shouldBe` Rampart.Equal
+
+      Hspec.it "after" $ do
+        relate (6, 6) (5, 5) `Hspec.shouldBe` Rampart.After
+
   Hspec.describe "invert" $ do
 
     Hspec.it "inverts the after relation" $ do


### PR DESCRIPTION
This fixes part of #2. Previously two empty intervals at the same value would be related as `Meets`. This PR changes that to be `Equal` instead.

``` hs
-- before
>>> relate (toInterval (5, 5)) (toInterval (5, 5))
Meets

-- after
>>> relate (toInterval (5, 5)) (toInterval (5, 5))
Equal
```